### PR TITLE
Add tests for setup command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.jar filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ The `setup` command also has the following flags/options:
 
 ```
 -h, --help              help for setup
--i, --instance string   Instance where the given repository from 'mount' should be mounted.
+-i, --instance string   Instance where the given repository from 'mount' should be mounted. Must be used with the mount flag
 -m, --mount string      Path to an existing AEM repository that will be mounted to your instances. Must be used with the instance flag.
--p, --path string       Path where AEM should be setup. Default is the current directory you are in. (default ".")
+-p, --path string       Path where AEM should be setup. Default is the current directory you are in.
 ```
 
 Example:
 
 ```bash
-$ aem-setup-cli setup /path/to/license.properties -p /path/to/setup/env -m /path/to/crx-quickstart
+$ aem-setup-cli setup /path/to/license.properties -p /path/to/setup/env -m /path/to/crx-quickstart -i author
 ```
 
 ## Contributing

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,8 @@ var rootCmd = &cobra.Command{
 	Use:   "aem-setup-cli",
 	Short: "CLI tool to help setup AEM locally",
 	Long:  `CLI tool that makes it easy to setup your environment to run AEM locally.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return nil
 	},
 }
 
@@ -25,4 +26,8 @@ func Execute() {
 }
 
 func init() {
+	setup := NewSetupImpl()
+	setupCmd := NewSetupCommand(setup)
+
+	rootCmd.AddCommand(setupCmd)
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -5,73 +5,86 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/ChristianLapinig/aem-setup-cli/lib"
 	"github.com/spf13/cobra"
 )
 
-// setupCmd represents the setup command
-var setupCmd = &cobra.Command{
-	Use:   "setup",
-	Short: "Creates the necessary files and folders for a local AEM environment.",
-	Long:  `'setup' creates the necessary files and folders to run a local AEM environment.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: Copy license.properties file. Needs to be an argument
-		if len(args) < 1 {
-			fmt.Println("license.properties file is required. Exiting...")
-			os.Exit(1)
-		}
-
-		if len(args) < 2 {
-			fmt.Println("Path to quickstart JAR is required. Exiting...")
-			os.Exit(1)
-		}
-
-		licenseProperties := args[0]
-		quickstartPath := args[1]
-		setupPath, _ := cmd.Flags().GetString("path")
-		repoPath, _ := cmd.Flags().GetString("mount")
-		instance, _ := cmd.Flags().GetString("instance")
-
-		authorPath := filepath.Join(setupPath, "author")
-		publishPath := filepath.Join(setupPath, "publish")
-
-		fmt.Println("Creating author and publish folders in", setupPath)
-		lib.CheckErr(lib.CreateFolder(authorPath))
-		lib.CheckErr(lib.CreateFolder(publishPath))
-		fmt.Println("Successfully created author and publish folders")
-
-		fmt.Println("Copying license.properties file to respective instances")
-		lib.CheckErr(lib.Copy(licenseProperties, filepath.Join(authorPath, "license.properties")))
-		lib.CheckErr(lib.Copy(licenseProperties, filepath.Join(publishPath, "license.properties")))
-		fmt.Println("Successfully copied license.properties to author and publish folders")
-
-		// TODO: It should be specified where to mount the given repository
-		// should it be in the author or publish folder? or both?
-
-		fmt.Println("Copying quickstart JAR to respective folders")
-		lib.CheckErr(lib.Copy(quickstartPath, filepath.Join(authorPath, "aem-author-p4502.jar")))
-		lib.CheckErr(lib.Copy(quickstartPath, filepath.Join(publishPath, "aem-publish-p4503.jar")))
-		fmt.Println("Successfully copied the quickstart jar to author and publish folder")
-
-		if repoPath != "" && instance != "" {
-			fmt.Println("Copying existing repository to", setupPath+"/"+instance)
-			lib.CheckErr(lib.Copy(repoPath, filepath.Join(setupPath, instance, "crx-quickstart")))
-			fmt.Println("Successfully mounted existing repository to", setupPath+"/"+instance)
-		} else if repoPath != "" && instance == "" {
-			fmt.Println("An instance must be specified when using the 'mount' command.")
-			os.Exit(1)
-		}
-
-		fmt.Println("Done. Local AEM environment is now setup.")
-	},
+type Setup interface {
+	Setup(licensProperties, quickstartPath, setupPath, repoPath, instance string) error
 }
 
-func init() {
-	rootCmd.AddCommand(setupCmd)
-	setupCmd.Flags().StringP("path", "p", ".", "Path where AEM should be setup. Default is the current directory you are in.")
-	setupCmd.Flags().StringP("mount", "m", "", "Path to an existing AEM repository that will be mounted to your instances. Must be used with the instance flag.")
-	setupCmd.Flags().StringP("instance", "i", "", "Instance where the given repository from 'mount' should be mounted.")
+type SetupImpl struct{}
+
+func NewSetupImpl() Setup {
+	return &SetupImpl{}
+}
+
+func (s *SetupImpl) Setup(licenseProperties, quickstartPath, setupPath, repoPath, instance string) error {
+	authorPath := filepath.Join(setupPath, "author")
+	publishPath := filepath.Join(setupPath, "publish")
+
+	fmt.Println("Creating author and publish folders in", setupPath)
+	lib.CheckErr(lib.CreateFolder(authorPath))
+	lib.CheckErr(lib.CreateFolder(publishPath))
+	fmt.Println("Successfully created author and publish folders")
+
+	fmt.Println("Copying license.properties file to respective instances")
+	lib.CheckErr(lib.Copy(licenseProperties, filepath.Join(authorPath, "license.properties")))
+	lib.CheckErr(lib.Copy(licenseProperties, filepath.Join(publishPath, "license.properties")))
+	fmt.Println("Successfully copied license.properties to author and publish folders")
+
+	fmt.Println("Copying quickstart JAR to respective folders")
+	lib.CheckErr(lib.Copy(quickstartPath, filepath.Join(authorPath, "aem-author-p4502.jar")))
+	lib.CheckErr(lib.Copy(quickstartPath, filepath.Join(publishPath, "aem-publish-p4503.jar")))
+	fmt.Println("Successfully copied the quickstart jar to author and publish folder")
+
+	if repoPath != "" && instance != "" {
+		fmt.Println("Copying existing repository to", setupPath+"/"+instance)
+		lib.CheckErr(lib.Copy(repoPath, filepath.Join(setupPath, instance, "crx-quickstart")))
+		fmt.Println("Successfully mounted existing repository to", setupPath+"/"+instance)
+	} else if repoPath != "" && instance == "" {
+		fmt.Println("An instance must be specified when using the 'mount' command.")
+		return nil
+	}
+
+	return nil
+}
+
+func NewSetupCommand(setup Setup) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Creates the necessary files and folders for a local AEM environment.",
+		Long:  `'setup' creates the necessary files and folders to run a local AEM environment.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Path to license.properties file is required. Exiting...")
+				return nil
+			}
+
+			if len(args) < 2 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Path to quickstart JAR is required. Exiting...")
+				return nil
+			}
+
+			licenseProperties := args[0]
+			quickstartPath := args[1]
+			setupPath, _ := cmd.Flags().GetString("path")
+			repoPath, _ := cmd.Flags().GetString("mount")
+			instance, _ := cmd.Flags().GetString("instance")
+
+			setup.Setup(licenseProperties, quickstartPath, setupPath, repoPath, instance)
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Setup of local AEM environment complete.")
+			return nil
+		},
+	}
+
+	// Initialize flags
+	cmd.Flags().StringP("path", "p", ".", "Path where AEM should be setup. Default is the current directory you are in. Must be used with the mount flag.")
+	cmd.Flags().StringP("mount", "m", "", "Path to an existing AEM repository that will be mounted to your instances. Must be used with the instance flag.")
+	cmd.Flags().StringP("instance", "i", "", "Instance where the given repository from 'mount' should be mounted.")
+
+	return cmd
 }

--- a/cmd/setup_cmd_test.go
+++ b/cmd/setup_cmd_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+type MockSetup struct{}
+
+func NewMockSetup() Setup {
+	return &MockSetup{}
+}
+
+func (s *MockSetup) Setup(licensProperties, quickstartPath, setupPath, repoPath, instance string) error {
+	return nil
+}
+
+func TestSetupCommand(t *testing.T) {
+	t.Run("Should throw error if license.properties file is not passed", func(t *testing.T) {
+		actual := new(bytes.Buffer)
+		setup := NewMockSetup()
+		setupCmd := NewSetupCommand(setup)
+		setupCmd.SetOut(actual)
+		setupCmd.SetErr(actual)
+		setupCmd.SetArgs([]string{})
+		setupCmd.Execute()
+
+		expected := "Path to license.properties file is required. Exiting...\n"
+
+		AssertOutput(t, actual.String(), expected)
+	})
+
+	t.Run("Should throw error if path to quickstart JAR is not passed", func(t *testing.T) {
+		actual := new(bytes.Buffer)
+		setup := NewMockSetup()
+		setupCmd := NewSetupCommand(setup)
+		setupCmd.SetOut(actual)
+		setupCmd.SetErr(actual)
+		setupCmd.SetArgs([]string{"./license.properties"})
+		setupCmd.Execute()
+
+		expected := "Path to quickstart JAR is required. Exiting...\n"
+
+		AssertOutput(t, actual.String(), expected)
+	})
+
+	t.Run("Setup of local AEM environment is successful", func(t *testing.T) {
+		actual := new(bytes.Buffer)
+		setup := NewMockSetup()
+		setupCmd := NewSetupCommand(setup)
+		setupCmd.SetOut(actual)
+		setupCmd.SetErr(actual)
+		setupCmd.SetArgs([]string{"./license.properties", "./cq-quickstart.jar"})
+		setupCmd.Execute()
+
+		expected := "Setup of local AEM environment complete.\n"
+
+		AssertOutput(t, actual.String(), expected)
+	})
+}
+
+func AssertOutput(t testing.TB, actual, expected string) {
+	if actual != expected {
+		t.Errorf("Failed: Actual - %q, Expected - %q", actual, expected)
+	}
+}


### PR DESCRIPTION
- Refactor the setup command to make it testable
- Add tests for the setup command that covers:
  - If the `license.properties` or the `cq-quickstart.jar` paths are not specified
  - If the setup is successful